### PR TITLE
Updated step 6 of readme which may now be redundant…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 0. Find the project files
 
-        cd /vagrant
+        cd ~/vagrant
 
 0. Install dependencies
 


### PR DESCRIPTION
The vagrant provisioner adds this step to the .bashrc to cd into vagrant dir, so the whole step 6 is redundant. Is it the plan to keep the cd vagrant at the bottom of the .bashrc?
